### PR TITLE
docs: make --max-chars explicit in help and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 tree2md                        # Pretty tree in terminal
 tree2md | pbcopy               # Pipe-friendly tree for clipboard
 tree2md -c -I "*.rs" -L 2     # Tree + file contents for AI context
+tree2md -c --max-chars 30000   # Fit contents within token budget
 ```
 
 ---
@@ -108,6 +109,8 @@ cargo install --path .
 | Flag | Description |
 |------|-------------|
 | `-c, --contents` | Append file contents as code blocks |
+| `--max-chars <N>` | Limit total content to N characters (requires `-c`) |
+| `--contents-mode {head\|nest}` | Truncation strategy (default: `head`) |
 
 ### Statistics
 
@@ -158,6 +161,12 @@ tree2md . -L 3 | pbcopy
 
 ```bash
 tree2md . -c -I "*.rs" -I "*.toml" | pbcopy
+```
+
+**Fit contents within token budget**
+
+```bash
+tree2md . -c --max-chars 30000 | pbcopy
 ```
 
 **Quick project overview**

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -61,11 +61,13 @@ QUICK START:
   tree2md                          # Pretty tree in terminal (TTY)
   tree2md | pbcopy                 # Pipe-friendly tree for clipboard
   tree2md -c -I "*.rs" -L 2       # Tree + file contents for AI context
+  tree2md -c --max-chars 30000    # Fit contents within token budget
 
 OUTPUT MODES (auto-detected):
   TTY    Pretty output with emoji, LOC bars, stats, tree characters
   Pipe   Simple tree + line counts — ideal for pbcopy or LLM pipes
   -c     Tree + file contents (code-fenced) — full context for agents
+  -c --max-chars N   Truncate contents to fit within N characters
 
 FILTERING:
   -L N                 Limit depth to N levels
@@ -167,7 +169,7 @@ pub struct Args {
     #[arg(short = 'c', long = "contents")]
     pub contents: bool,
 
-    /// Limit total content characters (only with -c)
+    /// Limit total content to N characters — controls AI context budget (only with -c)
     #[arg(
         long = "max-chars",
         value_name = "N",
@@ -176,7 +178,7 @@ pub struct Args {
     )]
     pub max_chars: Option<usize>,
 
-    /// Content extraction strategy when --max-chars is set
+    /// Truncation strategy: head = first N lines, nest = collapse deep indentation (only with --max-chars)
     #[arg(
         long = "contents-mode",
         value_enum,


### PR DESCRIPTION
## Summary
- Add `--max-chars` example to QUICK START in both CLI help and README
- Add `--max-chars N` line to OUTPUT MODES section in CLI help
- Add `--max-chars` and `--contents-mode` rows to README Contents table
- Add "Fit contents within token budget" use case example to README
- Improve `--max-chars` and `--contents-mode` help descriptions

Having `--max-chars` prominently visible makes it much easier for AI agents to optimize the context they receive.

## Test plan
- [x] `mise run verify` — all 219 tests pass
- [x] `cargo run -- --help` shows updated help text

🤖 Generated with [Claude Code](https://claude.com/claude-code)