### PR TITLE
chore: bump version to v0.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.4] - 2026-02-26
+
+### Fixed
+- Prune nested git repositories, worktrees, and submodules — directories containing a `.git` entry are now automatically excluded as separate repository boundaries
+- Support `.git/info/exclude` patterns for per-repo local excludes
+
+### Improved
+- Make `--max-chars` explicit in help and README
+
 ## [0.9.3] - 2026-02-25
 
 ### Fixed
@@ -337,7 +346,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Hidden file support
 - Multi-language support (English/Japanese)
 
-[Unreleased]: https://github.com/zawakin/tree2md/compare/v0.9.3...HEAD
+[Unreleased]: https://github.com/zawakin/tree2md/compare/v0.9.4...HEAD
+[0.9.4]: https://github.com/zawakin/tree2md/compare/v0.9.3...v0.9.4
 [0.9.3]: https://github.com/zawakin/tree2md/compare/v0.9.2...v0.9.3
 [0.9.2]: https://github.com/zawakin/tree2md/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/zawakin/tree2md/compare/v0.9.0...v0.9.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,7 +737,7 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tree2md"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "assert_cmd",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree2md"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2021"
 authors = ["zawakin"]
 description = "Like the tree command, but outputs in Markdown. Optimized for AI agents."


### PR DESCRIPTION
## Summary
- Bump version to v0.9.4
- Update CHANGELOG.md with release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)